### PR TITLE
Add framed tranport option to server

### DIFF
--- a/aiothrift/protocol.py
+++ b/aiothrift/protocol.py
@@ -385,10 +385,10 @@ class TFramedTransport:
 
     def read(self, n=-1):
         if len(self.__read_buffer.getvalue()) == 0:
-            self.readFrame()
+            self.read_frame()
         return self.__read_buffer.read(n)
 
-    async def readFrame(self):
+    async def read_frame(self):
         buff = await self.__base.readexactly(4)
         sz, = unpack('!i', buff)
         self.__read_buffer = BytesIO(await self.__base.readexactly(sz))
@@ -401,7 +401,7 @@ class TFramedTransport:
         if 0 < remaining < n:
             raise IOError("Tried to read invalid amount from framed transport")
         elif remaining == 0:
-            await self.readFrame()
+            await self.read_frame()
 
         return self.__read_buffer.read(n)
 

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -15,12 +15,12 @@ class Server:
         self.framed = framed
 
     async def __call__(self, reader, writer):
-        iproto = self.protocol_cls(reader)
-        oproto = self.protocol_cls(writer)
         if self.framed:
             reader = TFramedTransport(reader)
             writer = TFramedTransport(writer)
 
+        iproto = self.protocol_cls(reader)
+        oproto = self.protocol_cls(writer)
         while not reader.at_eof():
             try:
                 with async_timeout.timeout(self.timeout):

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -4,18 +4,23 @@ import async_timeout
 
 from .log import logger
 from .processor import TProcessor
-from .protocol import TBinaryProtocol
+from .protocol import TBinaryProtocol, TFramedTransport
 
 
 class Server:
-    def __init__(self, processor, protocol_cls=TBinaryProtocol, timeout=None):
+    def __init__(self, processor, protocol_cls=TBinaryProtocol, timeout=None, framed=False):
         self.processor = processor
         self.protocol_cls = protocol_cls
         self.timeout = timeout
+        self.framed = framed
 
     async def __call__(self, reader, writer):
         iproto = self.protocol_cls(reader)
         oproto = self.protocol_cls(writer)
+        if self.framed:
+            reader = TFramedTransport(reader)
+            writer = TFramedTransport(writer)
+
         while not reader.at_eof():
             try:
                 with async_timeout.timeout(self.timeout):
@@ -42,6 +47,7 @@ async def create_server(
     address=("127.0.0.1", 6000),
     protocol_cls=TBinaryProtocol,
     timeout=None,
+    framed=False,
     **kw,
 ):
     """ create a thrift server.
@@ -58,6 +64,6 @@ async def create_server(
     host, port = address
     processor = TProcessor(service, handler)
     server = await asyncio.start_server(
-        Server(processor, protocol_cls, timeout=timeout), host, port, **kw
+        Server(processor, protocol_cls, timeout=timeout, framed=framed), host, port, **kw
     )
     return server


### PR DESCRIPTION
Many async thrift servers used the "framed" protocol, which is incompatable with the unframed version and has to be set via configuration.  People interested in aiothrift may be migrating from eg. the Python 2 Twisted bindings which support only the framed protocol.  Therefore adding this option makes it a drop-in replacement for those servers.