### PR TITLE
Thrift server to exit while loop on exception

### DIFF
--- a/aiothrift/protocol.py
+++ b/aiothrift/protocol.py
@@ -422,9 +422,6 @@ class TFramedTransport:
     def close(self):
         return self.__base.close()
 
-    async def wait_closed(self):
-        return self.__base.wait_closed()
-
 
 class TProtocol:
     """

--- a/aiothrift/protocol.py
+++ b/aiothrift/protocol.py
@@ -422,6 +422,9 @@ class TFramedTransport:
     def close(self):
         return self.__base.close()
 
+    async def wait_closed(self):
+        return self.__base.wait_closed()
+
 
 class TProtocol:
     """

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -30,13 +30,13 @@ class Server:
                 with async_timeout.timeout(self.timeout):
                     await self.processor.process(iproto, oproto)
             except ConnectionError:
-                logger.debug(f"client {client_addr} has closed the connection")
+                logger.debug(f"client {client_addr} has closed the connection (connection error)")
                 writer.close()
             except asyncio.TimeoutError:
                 logger.debug(f"timeout when processing the client request from {client_addr}")
                 writer.close()
             except asyncio.IncompleteReadError:
-                logger.debug(f"client {client_addr} has closed the connection")
+                logger.debug(f"client {client_addr} has closed the connection (incomplete read error)")
                 writer.close()
             except Exception:
                 # app exception

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -21,18 +21,22 @@ class Server:
 
         iproto = self.protocol_cls(reader)
         oproto = self.protocol_cls(writer)
+        
+        client_addr = writer.get_extra_info('peername')
+        logger.debug(f"client {client_addr} has opened a connection")
+        
         while not reader.at_eof():
             try:
                 with async_timeout.timeout(self.timeout):
                     await self.processor.process(iproto, oproto)
             except ConnectionError:
-                logger.debug("client has closed the connection")
+                logger.debug(f"client {client_addr} has closed the connection")
                 writer.close()
             except asyncio.TimeoutError:
-                logger.debug("timeout when processing the client request")
+                logger.debug(f"timeout when processing the client request from {client_addr}")
                 writer.close()
             except asyncio.IncompleteReadError:
-                logger.debug("client has closed the connection")
+                logger.debug(f"client {client_addr} has closed the connection")
                 writer.close()
             except Exception:
                 # app exception

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -34,13 +34,12 @@ class Server:
         except asyncio.TimeoutError:
             logger.debug(f"timeout when processing the client request from {client_addr}")
         except asyncio.IncompleteReadError:
-            logger.debug(f"client {client_addr} has closed the connection (asyncio.IncompleteReadError)")
+            logger.debug(f"client {client_addr} has closed the connection")
         except Exception:
             # app exception
             logger.exception("unhandled app exception")
         finally:
             writer.close()
-            await writer.wait_closed()
 
 
 async def create_server(

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -16,6 +16,7 @@ class Server:
 
     async def __call__(self, reader, writer):
         client_addr = writer.get_extra_info('peername')
+        logger.debug(f"client {client_addr} has opened a connection")
 
         if self.framed:
             reader = TFramedTransport(reader)
@@ -24,8 +25,6 @@ class Server:
         iproto = self.protocol_cls(reader)
         oproto = self.protocol_cls(writer)
 
-        logger.debug(f"client {client_addr} has opened a connection")
-        
         try:
             while not reader.at_eof():
                 with async_timeout.timeout(self.timeout):

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -41,6 +41,7 @@ class Server:
             logger.exception("unhandled app exception")
         finally:
             writer.close()
+            await writer.wait_closed()
 
 
 async def create_server(

--- a/aiothrift/server.py
+++ b/aiothrift/server.py
@@ -15,34 +15,32 @@ class Server:
         self.framed = framed
 
     async def __call__(self, reader, writer):
+        client_addr = writer.get_extra_info('peername')
+
         if self.framed:
             reader = TFramedTransport(reader)
             writer = TFramedTransport(writer)
 
         iproto = self.protocol_cls(reader)
         oproto = self.protocol_cls(writer)
-        
-        client_addr = writer.get_extra_info('peername')
+
         logger.debug(f"client {client_addr} has opened a connection")
         
-        while not reader.at_eof():
-            try:
+        try:
+            while not reader.at_eof():
                 with async_timeout.timeout(self.timeout):
                     await self.processor.process(iproto, oproto)
-            except ConnectionError:
-                logger.debug(f"client {client_addr} has closed the connection (connection error)")
-                writer.close()
-            except asyncio.TimeoutError:
-                logger.debug(f"timeout when processing the client request from {client_addr}")
-                writer.close()
-            except asyncio.IncompleteReadError:
-                logger.debug(f"client {client_addr} has closed the connection (incomplete read error)")
-                writer.close()
-            except Exception:
-                # app exception
-                logger.exception("unhandled app exception")
-                writer.close()
-        writer.close()
+        except ConnectionError:
+            logger.debug(f"client {client_addr} has closed the connection (ConnectionError)")
+        except asyncio.TimeoutError:
+            logger.debug(f"timeout when processing the client request from {client_addr}")
+        except asyncio.IncompleteReadError:
+            logger.debug(f"client {client_addr} has closed the connection (asyncio.IncompleteReadError)")
+        except Exception:
+            # app exception
+            logger.exception("unhandled app exception")
+        finally:
+            writer.close()
 
 
 async def create_server(


### PR DESCRIPTION
Hi, I've been using this library to (mostly) great success, but recently ran into a problem where I had a client connecting to my thrift server and every time the client was powered on, it would try to connect and immediately raise a `ConnectionError`. This led to my server getting stuck in an infinite loop, because the exception was caught within a `while` loop.

I moved the `while` loop inside the `try` block and that seemed to solve the problem. Of course it's possible there are other effects of this change that I'm not accounting for, in which case maybe it doesn't make sense to push this PR back up to the library - but everything seems to be working great from my testing so far!

Note that I also added some additional logging information to include the address of the client for a given request.