### PR TITLE
add Compatible with the original thrift

### DIFF
--- a/aiothrift/protocol.py
+++ b/aiothrift/protocol.py
@@ -139,7 +139,13 @@ def write_val(writer, ttype, val, spec=None):
 
     elif ttype == TType.STRUCT:
         for fid in iter(val.thrift_spec):
-            f_spec = val.thrift_spec[fid]
+            if fid is None:
+                continue
+            if type(fid) == tuple:
+                f_spec = fid[1:]
+                fid = fid[0]
+            else:
+                f_spec = val.thrift_spec[fid]
             if len(f_spec) == 3:
                 f_type, f_name, f_req = f_spec
                 f_container_spec = None


### PR DESCRIPTION
When the server uses the original thrift and transmits the type created by itself in ttypes.py, here thrift_spec structure will be inconsistent, which is judged to solve this problem.
sorry，My English is not good.
这里的server如果是普通的，客户端是aio的,  由xxxx.thrift文件生成的ttypes.py文件里我需要传输的自定义的数据类型，如果是这样我aio的客户端请求server需要将这个自定义的对象传过去会在本次修改位置报异常，1是传来的thrift_spec第一个值为None，后面的fid是类似(1, TType.I32, 'o_id', None, None, )这样的元组正常值应该是123456这样的序号